### PR TITLE
Don't fail when encountering invalid files, skip them

### DIFF
--- a/fuzzy_finder/src/lib.rs
+++ b/fuzzy_finder/src/lib.rs
@@ -37,13 +37,12 @@ impl<T> FuzzyFinder<T>
 where
     T: Clone,
 {
-    fn new(functions: Vec<Item<T>>) -> Self {
+    fn new(functions: Vec<Item<T>>, lines_to_show: i8) -> Self {
         // We need to know where to start rendering from. We can't do this later because
         // we overwrite the cursor. Maybe we shouldn't do this? (TODO)
         let mut stdout = stdout().into_raw_mode().unwrap();
 
         write!(stdout, "{}", termion::cursor::Save).unwrap();
-        let lines_to_show: i8 = 8;
         let mut positive_space_remaining = 0;
         let console_offset = if stdout.cursor_pos().is_ok() {
             let cursor_pos_y = stdout.cursor_pos().unwrap().1;
@@ -215,8 +214,8 @@ where
     }
 
     /// The main entry point for the fuzzy finder.
-    pub fn find(items: Vec<Item<T>>) -> Result<Option<T>> {
-        let mut state = FuzzyFinder::new(items);
+    pub fn find(items: Vec<Item<T>>, lines_to_show: i8) -> Result<Option<T>> {
+        let mut state = FuzzyFinder::new(items, lines_to_show);
 
         state.update_matches();
 

--- a/lk/src/executables.rs
+++ b/lk/src/executables.rs
@@ -3,7 +3,12 @@ use crate::{ui::print_root_header};
 use content_inspector::{inspect, ContentType};
 use pad::{Alignment, PadStr};
 use pastel_colours::{DARK_GREEN_FG, RESET_FG};
-use std::{io::Read, os::unix::fs::PermissionsExt, path::PathBuf, fs::Permissions};
+use std::{
+    fs::Permissions,
+    io::Read,
+    os::unix::fs::PermissionsExt,
+    path::{Component, Path, PathBuf},
+};
 use walkdir::{DirEntry, WalkDir};
 
 pub struct Executable {
@@ -18,7 +23,7 @@ pub struct Executables {
 }
 
 impl Executables {
-    pub fn new(root: &str) -> Self {
+    pub fn new(root: &str, ignores: &[PathBuf]) -> Self {
         // TODO: Load this from .gitignore/other ignore files
         let ignored = vec![
             "target",
@@ -36,7 +41,7 @@ impl Executables {
         ];
         let walker = WalkDir::new(root).into_iter();
         let mut executables: Vec<Executable> = Vec::new();
-        for result in walker.filter_entry(|e| (!is_ignored(e, &ignored))) {
+        for result in walker.filter_entry(|e| !is_ignored(e.path(), &ignored, ignores)) {
             let entry = match result {
                 Ok(entry) => entry,
                 Err(e) => match e.path() {
@@ -125,17 +130,13 @@ fn has_permissions(permissions: &Permissions) -> bool {
     permissions.mode() != 33279 
 }
 
-fn is_ignored(entry: &DirEntry, ignores: &[&str]) -> bool {
-    entry
-        .file_name()
-        .to_str()
-        .map(|s| {
-            for ignored in ignores.iter() {
-                if s.contains(ignored) {
-                    return true;
-                }
-            }
-            false
+fn is_ignored(p: &Path, ignored: &[&str], ignores: &[PathBuf]) -> bool {
+    ignores.iter().any(|s| p.starts_with(s))
+        || ignored.iter().any(|i| {
+            p.components().any(|c| match c {
+                Component::Normal(c) => *c == **i,
+                _ => false,
+            })
         })
         .unwrap_or(false)
 }

--- a/lk/src/executables.rs
+++ b/lk/src/executables.rs
@@ -39,7 +39,13 @@ impl Executables {
         for result in walker.filter_entry(|e| (!is_ignored(e, &ignored))) {
             let entry = match result {
                 Ok(entry) => entry,
-                Err(_) => panic!("Couldn't read dir!"),
+                Err(e) => match e.path() {
+                    Some(p) => {
+                        log::warn!("Could not open path {}", p.to_string_lossy());
+                        continue
+                    }
+                    None => panic!("Could not read dir !"),
+                },
             };
             if should_include_file(&entry) {
                 let path = entry.into_path();

--- a/lk/src/main.rs
+++ b/lk/src/main.rs
@@ -83,7 +83,12 @@ fn main() -> Result<()> {
     let executables = Executables::new(".");
     sp.stop();
 
-    let scripts: Vec<Script> = executables.executables.iter().map(Script::new).collect();
+    let scripts: Vec<Script> = executables
+        .executables
+        .iter()
+        .map(Script::new)
+        .filter_map(Result::ok)
+        .collect();
 
     // Prints all scripts
     // scripts.iter().for_each(|script| {
@@ -156,7 +161,7 @@ fn list(executables: Executables, args: Cli) -> Result<()> {
         // Is it a script that exists on disk?
         if let Some(executable) = executables.get(&script) {
             // Yay, confirmed script
-            let script = Script::new(executable);
+            let script = Script::new(executable)?;
             // Did the user pass a function?
             if let Some(function) = args.function {
                 // Is it a function that exists in the script we found?

--- a/lk/src/main.rs
+++ b/lk/src/main.rs
@@ -6,6 +6,8 @@ mod script;
 mod shells;
 mod ui;
 
+use std::path::PathBuf;
+
 use anyhow::Result;
 use bash_file::BashFile;
 use executables::Executables;
@@ -46,6 +48,9 @@ struct Cli {
     script: Option<String>,
     /// Optional: the name of the function to run.
     function: Option<String>,
+    /// Optional: paths to ignore in the search
+    #[structopt(long, short)]
+    ignore: Vec<PathBuf>,
     /// Optional: params for the function. We're not processing them yet (e.g. validating) but
     /// they need to be permitted as a param to lk.
     #[allow(dead_code)]
@@ -80,7 +85,14 @@ fn main() -> Result<()> {
     log::info!("\n\nStarting lk...");
 
     let sp = Spinner::new(&Spinners::Line, "".to_string());
-    let executables = Executables::new(".");
+    let executables = Executables::new(
+        ".",
+        &args
+            .ignore
+            .iter()
+            .map(|p| PathBuf::from(".").join(p))
+            .collect::<Vec<_>>(),
+    );
     sp.stop();
 
     let scripts: Vec<Script> = executables

--- a/lk/src/script.rs
+++ b/lk/src/script.rs
@@ -1,6 +1,7 @@
 /// Parses a script file and extracts comments and functions.
 use crate::executables::Executable;
 use crate::ui::{print_no_functions_in_script_help, print_script_header};
+use anyhow::Result;
 use pad::{Alignment, PadStr};
 use pastel_colours::{GREEN_FG, RESET_FG};
 use regex::bytes::Regex;
@@ -23,7 +24,7 @@ pub struct Script {
 }
 
 impl Script {
-    pub fn new(executable: &Executable) -> Self {
+    pub fn new(executable: &Executable) -> Result<Self> {
         let lines = match read_lines(&executable.path) {
             Ok(lines) => lines,
             Err(err) => {
@@ -31,7 +32,7 @@ impl Script {
                     "Unable to read executable: {}. Error was: {err}",
                     &executable.path.to_string_lossy()
                 );
-                panic!("blah:{}", err)
+                anyhow::bail!("Permissiond denied in opening script");
             }
         };
 
@@ -70,12 +71,12 @@ impl Script {
             }
         }
 
-        Self {
+        Ok(Self {
             comment: included_comments,
             functions: included_functions,
             path: executable.path.to_owned(),
             absolute_path: executable.absolute_path.to_owned(),
-        }
+        })
     }
 
     pub fn get(&self, function_name: &str) -> Option<&Function> {


### PR DESCRIPTION
When I tried to use `lk` on a large tree of directories it encountered some files it could not read. Instead of failing, I just made the option to skip them